### PR TITLE
ascii-image-converter: Build according to package guidelines

### DIFF
--- a/ascii-image-converter/.SRCINFO
+++ b/ascii-image-converter/.SRCINFO
@@ -6,8 +6,7 @@ pkgbase = ascii-image-converter
 	arch = x86_64
 	license = Apache
 	makedepends = go
-	conflicts = ascii-image-converter-git
-	source = ascii-image-converter-1.13.0.tar.gz::https://github.com/TheZoraiz/ascii-image-converter/archive/refs/tags/v1.13.0.tar.gz
+	source = https://github.com/thezoraiz/ascii-image-converter/archive/v1.13.0.tar.gz
 	sha256sums = e9774374d6d3e0504bba70e2499b5472a216c93c61a0cafd0265ae47e9c7c5e5
 
 pkgname = ascii-image-converter

--- a/ascii-image-converter/PKGBUILD
+++ b/ascii-image-converter/PKGBUILD
@@ -8,17 +8,19 @@ arch=('x86_64')
 url="https://github.com/TheZoraiz/ascii-image-converter"
 license=('Apache')
 makedepends=('go')
-conflicts=("$pkgname-git")
-source=("$pkgname-$pkgver.tar.gz::https://github.com/TheZoraiz/$pkgname/archive/refs/tags/v$pkgver.tar.gz")
+source=("https://github.com/thezoraiz/$pkgname/archive/v$pkgver.tar.gz")
 sha256sums=('e9774374d6d3e0504bba70e2499b5472a216c93c61a0cafd0265ae47e9c7c5e5')
 
 build() {
-  cd $pkgname-$pkgver
-  go build
+	cd "$pkgname-$pkgver"
+	export CGO_CPPFLAGS="${CPPFLAGS}"
+	export CGO_CFLAGS="${CFLAGS}"
+	export CGO_CXXFLAGS="${CXXFLAGS}"
+	export CGO_LDFLAGS="${LDFLAGS}"
+	export GOFLAGS="-buildmode=pie -trimpath -mod=readonly -modcacherw"
+	go build -v -o "$pkgname"
 }
 
 package() {
-  install -Dm755 $pkgname-$pkgver/ascii-image-converter -t "$pkgdir/usr/bin/"
+	install -Dm 755 "$pkgname-$pkgver/$pkgname" -t "$pkgdir/usr/bin/"
 }
-
-# vim:set ts=2 sw=2 et:


### PR DESCRIPTION
This patch builds the package using the recommended [golang flags](https://wiki.archlinux.org/title/Go_package_guidelines#Flags_and_build_options), removes the conflicts variable as this is already defined in the `-git` package variant (and should only be defined there) and introduces some cosmetic changes. :)

Cheers.