### PR TITLE
Fix `eww`'s Rust builing toolchain

### DIFF
--- a/eww-git/PKGBUILD
+++ b/eww-git/PKGBUILD
@@ -18,7 +18,6 @@ b2sums=('SKIP')
 
 prepare() {
 	cd $_pkgname
-	export RUSTUP_TOOLCHAIN=stable
 	cargo fetch --locked --target "$CARCH-unknown-linux-gnu"
 }
 
@@ -28,9 +27,7 @@ pkgver() {
 
 build() {
 	cd $_pkgname
-	export RUSTUP_TOOLCHAIN=stable
-	export CARGO_TARGET_DIR=target
-	cargo build --frozen --release
+	cargo build --frozen --release --target-dir "target"
 }
 
 package() {

--- a/eww/PKGBUILD
+++ b/eww/PKGBUILD
@@ -22,15 +22,12 @@ validpgpkeys=(
 
 prepare() {
 	cd $pkgname
-	export RUSTUP_TOOLCHAIN=stable
 	cargo fetch --target "$CARCH-unknown-linux-gnu"
 }
 
 build() {
 	cd $pkgname
-	export RUSTUP_TOOLCHAIN=stable
-	export CARGO_TARGET_DIR=target
-	cargo build --frozen --release
+	cargo build --frozen --release --target-dir "target"
 }
 
 package() {


### PR DESCRIPTION
`Eww` uses the `rust-toolchain.toml` file to describe which toolchain should be used for compilation. Although, the AUR packages set the `RUSTUP_TOOLCHAIN` environmental variables of their own. Since this variable has higher priority (see https://rust-lang.github.io/rustup/overrides.html), a wrong toolchain is used and it can lead to unpleasant situations such as the `time` crate not being able to compile.

The `RUSTUP_TOOLCHAIN` variable is redundant, `Eww` handles it itself.

Resolves https://github.com/elkowar/eww/issues/1141 (I think)